### PR TITLE
Precise capability change

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To install the plugin, head over to the machine with Homebridge set up and run
 npm install -g homebridge-wol
 ```
 
-_Note, homebridge-wol requires root permissions due to the use of pinging and magic packages. Start homebridge with sudo: `sudo homebridge` or change permissions accordingly._
+_Note, homebridge-wol requires root permissions due to the use of pinging and magic packages. Start homebridge with sudo: `sudo homebridge` or change capabilities accordingly (´setcap cap_net_raw=pe /path/to/bin/node`)._
 
 ###### Configuration
 


### PR DESCRIPTION
To allow a RAW socket from a non-root user, you need the right capabilities, not permissions, because running `node` setuid is a very bad idea. Therefore, you can add only the capability to open raw sockets to the `node` binary with the tool `setcap` from Debian/Ubuntu package `libcap2-bin`.