### PR TITLE
Status does not change after shutdown or waking up

### DIFF
--- a/lib/network-device.js
+++ b/lib/network-device.js
@@ -82,15 +82,13 @@ class NetworkDevice {
   pingerCallback(newState) {
     if (newState === true) {
       // Device is online.
-      if (this.status === Status.Online) return;
-      if (this.status === (Status.Offline || Status.ShuttingDown)) {
+      if (this.status !== Status.Online) {
         this.pingLog('Pinger saw device online; setting to Online.');
         this.setStatus(Status.Online);
       }
     } else {
       // Device has gone offline.
-      if (this.status === Status.Offline) return;
-      if (this.status === (Status.Online || Status.ShuttingDown)) {
+      if (this.status !== Status.Offline) {
         this.pingLog('Pinger can\'t see device; setting to Offline.');
         this.setStatus(Status.Offline);
       }


### PR DESCRIPTION
The status never changed from 'Shutting down' to 'offline' and 'Waking Up' to 'Online' because comparing like 'if (this.status === (Status.Offline || Status.ShuttingDown))' does not work. 
If shutdown or wake up fails the status should change back to 'Offline' or 'Online'.