### PR TITLE
Clarify "ip" and "mac" parameter formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ _Note: using username and passwords in a command is heavily discouraged as this 
 | --------- | --------------------------------------------------------------- | ---------|
 | accessory | The type of accessory - has to be "NetworkDevice"               | Yes      |
 | name      | The name of the device - used in HomeKit apps as well as Siri, default `My Computer` | Yes      |
-| mac       | The device's MAC address - used to send Magic Packets         | No       |
-| ip        | The IPv4 address of the device - used to check current status | No       |
+| mac       | The device's MAC address (without any colon separators) - used to send Magic Packets         | No       |
+| ip        | The IPv4 address or hostname of the device - used to check current status | No       |
 | pingInterval      | Ping interval in seconds, only used if `ip` is set, default `2`                      | No       |
 | wakeGraceTime     | Number of seconds to wait after wake-up before checking online status and issuing the `wakeCommand`, default `45`   |  No       |
 | wakeCommand | Command to run after initial wake-up, useful for macOS users in need of running `caffeinate` |  No       |


### PR DESCRIPTION
The MAC Address should be in the form `A1A1A1A1A1A1`, not `A1:A1:A1:A1:A1:A1` - many other Wake-on-LAN tools expect the later format, so this could be confusing if not documented.

The IP Address option will actually accept a hostname (`mypc.local` or whatever), which is very useful when the IP address can change.