### PR TITLE
added a parameter to the ping function

### DIFF
--- a/lib/pinger.js
+++ b/lib/pinger.js
@@ -30,7 +30,7 @@ class Pinger {
   ping() {
     if (!this.pinging) {
       this.pinging = true;
-      ping.promise.probe(this.config.ip, {timeout: this.config.timeout / 1000})
+      ping.promise.probe(this.config.ip, {timeout: this.config.timeout / 1000, extra: ['-R'],})
         .then(response => {
           this.pinging = false;
 


### PR DESCRIPTION
Due to a strange behavior of my Mac mini that is explained [here](https://apple.stackexchange.com/questions/86690/why-does-my-mac-mini-answers-pings-while-asleep), it shows the computer always on even if it's in standby. -R parameter to the ping command (in Linux) solves the problem.