### PR TITLE
fix pinger not working correctly when using pingCommand

### DIFF
--- a/lib/pinger.js
+++ b/lib/pinger.js
@@ -24,7 +24,7 @@ class Pinger {
     if (this.config.pingCommand) {
       exec(this.config.pingCommand, error => {
         // If there is an error, the host is considered down and vice versa
-        this.pingCallback(Boolean(error));
+        this.pingCallback(!Boolean(error));
       });
     } else {
       // Timeout is given in seconds
@@ -44,7 +44,8 @@ class Pinger {
     if (this.config.pingCommand) {
       exec(this.config.pingCommand, error => {
         // If there is an error, the host is considered down and vice versa
-        this.pingCallback(Boolean(error));
+        this.pingCallback(!Boolean(error));
+	this.pinging = false;
       });
     } else {
       ping.promise.probe(this.config.ip, {timeout: this.config.timeout / 1000})


### PR DESCRIPTION
Boolean(error) is true when the command exits with a nonzero state. What is needed is false though. 
Also this.pinging needs to be set to false, else the ping function is only executed once.