### PR TITLE
Fix "not responding" errors

### DIFF
--- a/lib/network-device.js
+++ b/lib/network-device.js
@@ -109,11 +109,11 @@ class NetworkDevice {
     if (shouldBeOnline) {
       this.log('NetworkDevice awake cycle started for "%s" (%s)', this.config.name, this.config.ip || 'unknown ip');
 
-      this.wake();
+      this.wake(callback);
     } else {
       this.log('NetworkDevice shutdown cycle started for "%s" (%s)', this.config.name, this.config.ip || 'unknown ip');
 
-      this.shutdown();
+      this.shutdown(callback);
     }
   }
 
@@ -122,7 +122,7 @@ class NetworkDevice {
     callback(null, this.status === Status.Online || this.status === Status.WakingUp);
   }
 
-  wake() {
+  wake(callback) {
     this.log('Attempting to wake up "%s" (%s)', this.config.name, this.config.ip || 'unknown ip');
 
     this.setStatus(Status.WakingUp);
@@ -167,11 +167,14 @@ class NetworkDevice {
       this.pinger.start();
     }
 
-    if (!woke)
+    if (woke) {
+      callback();
+    } else {
       this.log('No way of waking "%s" (%s) was configured', this.config.name, this.config.ip || 'unknown ip');
+    }
   }
 
-  shutdown() {
+  shutdown(callback) {
     this.setStatus(Status.ShuttingDown);
 
     // Disable the pinger
@@ -189,13 +192,18 @@ class NetworkDevice {
 
         if (this.pinger)
           this.pinger.start();
+
+        callback();
       });
 
       shutDown = true;
     }
 
-    if (!shutDown)
+    if (shutDown) {
+      callback();
+    } else {
       this.log('No way of shutting down "%s" (%s) was configured', this.config.name, this.config.ip || 'unknown ip');
+    }
   }
 
   // Called by homebridge to retrieve available services


### PR DESCRIPTION
Currently, HomeKit or Siri complains about devices "not responding" after changing the state.
This can be fixed by using the callback from the `set` handler.

Fixes #80 